### PR TITLE
Update azure-pipelines.yml to use main branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-  - master
+  - main
   
 variables:
   tag: 'r$(Build.BuildId)'


### PR DESCRIPTION
This PR updates the azure-pipelines.yml file to use the `main` branch instead of `master`. It has been automatically generated by performing a naive `s/\bmaster\b/main/g`, so please check it carefully.