### PR TITLE
Update .travis.yml to use main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ deploy:
   provider: script
   script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin && docker push spartan563/cv:latest
   on:
-    branch: master
+    branch: main


### PR DESCRIPTION
This PR updates the .travis.yml file to use the `main` branch instead of `master`. It has been automatically generated and this might not have worked correctly, so please check it carefully.